### PR TITLE
Add flatpak distribution support on Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.flatpak-builder
+_repo
+_build

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .flatpak-builder
 _repo
 _build
+*.flatpak

--- a/dist/flatpak/com.github.bytepath.appdata.xml
+++ b/dist/flatpak/com.github.bytepath.appdata.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop">
+  <id>com.github.bytepath</id>
+  <launchable type="desktop-id">com.github.bytepath.desktop</launchable>
+  <name>BYTEPATH</name>
+  <summary>A replayable arcade shooter with a focus on build theorycrafting. Use a massive skill tree, many classes and ships to create your own builds and defeat an ever increasing amount of enemies.</summary>
+  <description>
+    <p>BYTEPATH is a replayable arcade shooter with a focus on varied play styles with RPG elements. The game has a huge passive skill tree, classes and different ships through which you'll be able to try out lots of different builds to achieve ever increasing high scores and eventually beat the game.</p>
+
+    <p>Expect BYTEPATH to be a mix of Bit Blaster XL and Path of Exile, created with the intention of expanding Bit Blaster XL's relaxing and addictive gameplay with Path of Exile's build depth, build diversity and RPG elements.</p>
+    <p>
+      Gameplay
+      - Your ship can't stop moving, so you must turn it left and right or use your boost and brakes to prevent it from crashing on enemies.
+      - Your ship can't stop shooting, so you must continually kill enemies and collect ammo so you can keep using your powerful attacks.
+      - Items, resources and new attacks will be spawned randomly. Those will provide you with great boosts that may help you achieve higher scores in the current run.
+    </p>
+    <p>
+      Features
+      - 900+ nodes passive skill tree, allowing for a huge amount of varied play styles and builds
+      - 40+ classes, each giving stat boosts and modifiers which further enhance your build
+      - 10+ ships, each providing unique stats and modifiers (both positive and negative) that dramatically change the way you play
+      - 15+ enemy types which are spawned with increasing frequency as the run gets harder
+      - 40+ Steam achievements
+      - Entrancing soundtrack by AIRGLOW
+    </p>
+    <p>Steam store link: https://store.steampowered.com/app/760330/BYTEPATH/</p>
+  </description>
+  <screenshots>
+    <screenshot type="default">
+      <image type="source">https://cdn.cloudflare.steamstatic.com/steam/apps/760330/ss_4e42d9287fe65e7d2556b1e5bd6329739f8e08a5.1920x1080.jpg</image>
+      <image type="source">https://cdn.cloudflare.steamstatic.com/steam/apps/760330/ss_8ebb867f823deba67095fc763e3dd68b31c29437.1920x1080.jpg</image>
+      <image type="source">https://cdn.cloudflare.steamstatic.com/steam/apps/760330/ss_e33dffab02304a93661d3bae694563354df67120.1920x1080.jpg</image>
+      <image type="source">https://cdn.cloudflare.steamstatic.com/steam/apps/760330/ss_1b7e62602bfd29b64109b52fa36052ed1a04815e.1920x1080.jpg</image>
+      <image type="source">https://cdn.cloudflare.steamstatic.com/steam/apps/760330/ss_0e3fdf36baf98b7900adccdacedb7b4b6b685137.1920x1080.jpg</image>
+      <image type="source">https://cdn.cloudflare.steamstatic.com/steam/apps/760330/ss_4895fbffbfd13b13aa3704c87c64ceef84a66c15.1920x1080.jpg</image>
+      <image type="source">https://cdn.cloudflare.steamstatic.com/steam/apps/760330/ss_95ca229406097af61a69cc8cf95c73fc684f0379.1920x1080.jpg?t=1598901058</image>
+      <image type="source">https://cdn.cloudflare.steamstatic.com/steam/apps/760330/ss_dc6e73ff6fb860047472eef16866e482df0bd552.1920x1080.jpg?t=1598901058</image>
+      <image type="source">https://cdn.cloudflare.steamstatic.com/steam/apps/760330/ss_fcc35a6bd58d5ed927203fc81c71fa98741c513b.1920x1080.jpg?t=1598901058</image>
+    </screenshot>
+  </screenshots>
+  <releases>
+    <release version="1.0" date="2020-08-14"/>
+  </releases>
+  <url type="homepage">https://github.com/a327ex/BYTEPATH</url>
+  <url type="help">https://steamcommunity.com/app/760330</url>
+  <url type="bugtracker">https://github.com/a327ex/BYTEPATH/pulls</url>
+  <developer_name>a327ex</developer_name>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>MIT</project_license>
+  <content_rating type="oars-1.1">
+    <content_attribute id="language-humor">mild</content_attribute>
+    <content_attribute id="language-discrimination">mild</content_attribute>
+    <content_attribute id="social-chat">mild</content_attribute>
+    <content_attribute id="social-info">mild</content_attribute>
+    <content_attribute id="money-purchasing">mild</content_attribute>
+  </content_rating>
+  <update_contact>joshua.gage.stone_at_gmail.com</update_contact>
+</component>

--- a/dist/flatpak/com.github.bytepath.desktop
+++ b/dist/flatpak/com.github.bytepath.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=BYTEPATH
+Exec=bytepath
+Terminal=false
+Type=Application
+Icon=com.github.bytepath
+StartupWMClass=bytepath
+Comment=BYTEPATH
+Categories=Game;

--- a/dist/flatpak/com.github.bytepath.yml
+++ b/dist/flatpak/com.github.bytepath.yml
@@ -13,12 +13,11 @@ modules:
   - name: bytepath
     buildsystem: simple
     build-commands:
+      - install -Dm755 bytepath ${FLATPAK_DEST}/bin/bytepath
+      - install -Dm644 com.github.bytepath.jpg         ${FLATPAK_DEST}/share/icons/hicolor/512x512/apps/com.github.bytepath.png
+      - install -Dm644 com.github.bytepath.desktop     ${FLATPAK_DEST}/share/applications/com.github.bytepath.desktop
+      - install -Dm644 com.github.bytepath.appdata.xml ${FLATPAK_DEST}/share/appdata/com.github.appdata.xml
       - rm -rf love
-      - mv bytepath ${FLATPAK_DEST}/bin/bytepath
-      - mkdir -p ${FLATPAK_DEST}/share/{appdata,applications,icons/hicolor/512x512/apps}
-      - mv com.github.bytepath.jpg         ${FLATPAK_DEST}/share/icons/hicolor/512x512/apps/com.github.bytepath.png
-      - mv com.github.bytepath.desktop     ${FLATPAK_DEST}/share/applications
-      - mv com.github.bytepath.appdata.xml ${FLATPAK_DEST}/share/appdata/com.github.appdata.xml
       - zip -r ${FLATPAK_DEST}/bin/BYTEPATH.love *
     sources:
       - type: git

--- a/dist/flatpak/com.github.bytepath.yml
+++ b/dist/flatpak/com.github.bytepath.yml
@@ -1,0 +1,40 @@
+app-id: com.github.bytepath
+default-branch: stable
+runtime: org.freedesktop.Platform
+runtime-version: '20.08'
+sdk: org.freedesktop.Sdk
+command: bytepath
+finish-args:
+  - --socket=x11
+  - --socket=pulseaudio
+  - --device=dri
+modules:
+  - love2d-0.10.2.json
+  - name: bytepath
+    buildsystem: simple
+    build-commands:
+      - rm -rf love
+      - mv bytepath ${FLATPAK_DEST}/bin/bytepath
+      - mkdir -p ${FLATPAK_DEST}/share/{appdata,applications,icons/hicolor/512x512/apps}
+      - mv com.github.bytepath.jpg         ${FLATPAK_DEST}/share/icons/hicolor/512x512/apps/com.github.bytepath.png
+      - mv com.github.bytepath.desktop     ${FLATPAK_DEST}/share/applications
+      - mv com.github.bytepath.appdata.xml ${FLATPAK_DEST}/share/appdata/com.github.appdata.xml
+      - zip -r ${FLATPAK_DEST}/bin/BYTEPATH.love *
+    sources:
+      - type: git
+        url: https://github.com/a327ex/BYTEPATH
+        commit: 51ee3086ae3369a2c80e4e47d4b62d480af4fe89
+      - type: file
+        path: com.github.bytepath.desktop
+      - type: file
+        path: com.github.bytepath.appdata.xml
+      - type: patch
+        path: steam-framework-removal.patch
+      - type: file
+        url: https://cdn.cloudflare.steamstatic.com/steam/apps/760330/header.jpg
+        sha256: 9415e13d92709e4178a577db4b0d0e903093567d235c19e67c29fe978486624d
+        dest-filename: com.github.bytepath.jpg
+      - type: script
+        dest-filename: bytepath
+        commands:
+          - exec /app/bin/love /app/bin/BYTEPATH.love

--- a/dist/flatpak/com.github.bytepath.yml
+++ b/dist/flatpak/com.github.bytepath.yml
@@ -18,7 +18,7 @@ modules:
       - install -Dm644 com.github.bytepath.desktop     ${FLATPAK_DEST}/share/applications/com.github.bytepath.desktop
       - install -Dm644 com.github.bytepath.appdata.xml ${FLATPAK_DEST}/share/appdata/com.github.appdata.xml
       - rm -rf love
-      - zip -r ${FLATPAK_DEST}/bin/BYTEPATH.love *
+      - zip -x 'com.github.bytepath.*' -x bytepath -x dist -r ${FLATPAK_DEST}/bin/BYTEPATH.love *
     sources:
       - type: git
         url: https://github.com/a327ex/BYTEPATH

--- a/dist/flatpak/flatpak-build.sh
+++ b/dist/flatpak/flatpak-build.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/bash
+
+set -oeu pipefail
+
+readonly APP="com.github.bytepath"
+readonly APP_BUNDLE="${APP}-x86_64.flatpak"
+readonly BUILDDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+
+flatpak-builder --user \
+	       --install-deps-from=flathub \
+	       --force-clean \
+	       --state-dir="${BUILDDIR}/.flatpak-builder" \
+	       "${BUILDDIR}/_build" \
+	       --repo="${BUILDDIR}/_repo" \
+	       "${BUILDDIR}/${APP}.yml"
+
+flatpak build-bundle \
+	--arch=x86_64 \
+	"${BUILDDIR}/_repo" \
+	"${BUILDDIR}/${APP_BUNDLE}" \
+        "${APP}" \
+        stable

--- a/dist/flatpak/love2d-0.10.2.json
+++ b/dist/flatpak/love2d-0.10.2.json
@@ -1,0 +1,89 @@
+{
+    "name": "love2d",
+    "buildsystem": "simple",
+    "build-commands": [
+        "platform/unix/automagic",
+        "./configure --prefix=${FLATPAK_DEST}",
+        "make",
+        "make install"
+    ],
+    "sources": [
+        {
+            "type": "git",
+            "url": "https://github.com/love2d/love",
+            "tag": "0.10.2"
+        }
+    ],
+    "cleanup": [
+        "/lib/debug",
+        "/share",
+        "*.la"
+    ],
+    "modules": [
+        {
+            "name": "libmodplug",
+            "buildsystem": "simple",
+            "build-commands": [
+                "autoreconf --install",
+                "./configure --prefix=${FLATPAK_DEST}",
+                "make",
+                "make install"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/Konstanty/libmodplug",
+                    "commit": "d7ba5efd5816696fba668a23194940f796d62b95"
+                }
+            ],
+            "cleanup": [
+                "/include",
+                "/lib/debug",
+                "/lib/pkgconfig",
+                "*.la"
+            ]
+        },
+        {
+            "name": "physfs",
+            "buildsystem": "cmake",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://icculus.org/physfs/downloads/physfs-3.0.2.tar.bz2",
+                    "sha256": "304df76206d633df5360e738b138c94e82ccf086e50ba84f456d3f8432f9f863"
+                }
+            ],
+            "cleanup": [
+                "/bin",
+                "/include",
+                "/lib/debug",
+                "/lib/pkgconfig",
+                "*.a"
+            ]
+        },
+        {
+            "name": "luajit",
+            "buildsystem": "simple",
+            "build-commands": [
+                "sed -i 's@/usr/local@/app@g' Makefile",
+                "make",
+                "make install"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/LuaJIT/LuaJIT",
+                    "tag": "v2.0.5"
+                }
+            ],
+            "cleanup": [
+                "/include",
+                "/lib/lua",
+                "/lib/pkgconfig",
+                "/share/lua",
+                "/share/man",
+                "*.a"
+            ]
+        }
+    ]
+}

--- a/dist/flatpak/steam-framework-removal.patch
+++ b/dist/flatpak/steam-framework-removal.patch
@@ -1,0 +1,11 @@
+diff --git a/main.lua b/main.lua
+index 9a4e005..14d3ffb 100644
+--- a/main.lua
++++ b/main.lua
+@@ -1,6 +1,3 @@
+-Steam = require 'libraries/steamworks'
+-if type(Steam) == 'boolean' then Steam = nil end
+-
+ Object = require 'libraries/classic/classic'
+ Timer = require 'libraries/enhanced_timer/EnhancedTimer'
+ Input = require 'libraries/boipushy/Input'


### PR DESCRIPTION
This PR adds supports for flatpak as a distribution method on Linux. There are numerous advantages of flatpak, such as:

- Normalizing development configuration, as all dependencies are pulled directly from upstream instead of distributions
- Providing a reproducible build environment through containerization
- Being a portable packaging format that integrates with different desktops and distros
- Giving developers the freedom to distribute applications over repositories or as bundles.

In this case, a script could be used for building portable flatpak bundles on Linux:

```
[jstone@joshua-laptop BYTEPATH]$ dist/flatpak/flatpak-build.sh 
[jstone@joshua-laptop BYTEPATH]$ ls -lh dist/flatpak/com.github.bytepath-x86_64.flatpak 
-rw-r--r--. 1 jstone jstone 56M Oct 17 14:28 dist/flatpak/com.github.bytepath-x86_64.flatpak
[jstone@joshua-laptop BYTEPATH]$ flatpak install --user dist/flatpak/com.github.bytepath-x86_64.flatpak
[jstone@joshua-laptop flatpak]$ ls -lh ~/.local/share/flatpak/exports/bin/com.github.bytepath
lrwxrwxrwx. 1 jstone jstone 75 Oct 17 14:29 /home/jstone/.local/share/flatpak/exports/bin/com.github.bytepath -> ../../app/com.github.bytepath/current/active/export/bin/com.github.bytepath
```

I think this would have an improvement in Linux support, as users would no longer [have to set up build dependencies and patch files](https://www.reddit.com/r/linux_gaming/comments/hlwzjn/bytepath_a_replayable_arcade_shooter_with_a_focus/fx2j1ss/). Desktop shortcuts are also set up with this build.

If you have any interest in upstreaming this and/or submitting to [Flathub](https://flathub.org/home), then please let me know!